### PR TITLE
feat: Make OLLAMA_MODEL mandatory and apply refactorings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -14,19 +14,36 @@ from pathlib import Path
 import os
 from dotenv import load_dotenv
 from django.core.exceptions import ImproperlyConfigured
+from urllib.parse import urlparse
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+
 # Load environment variables from .env file
-load_dotenv(BASE_DIR / ".env")
+env_path = BASE_DIR / ".env"
+if not os.path.exists(env_path):
+    raise ImproperlyConfigured(f".env file not found at {env_path}")
+load_dotenv(env_path)
+
 
 # Ollama Configuration
-OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL")
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "").strip()
 if not OLLAMA_BASE_URL:
     raise ImproperlyConfigured("OLLAMA_BASE_URL is not set in the environment or .env file.")
+
+# validate scheme and normalize
+_parsed = urlparse(OLLAMA_BASE_URL)
+if _parsed.scheme not in ("http", "https"):
+    raise ImproperlyConfigured("OLLAMA_BASE_URL must start with http:// or https://")
 OLLAMA_BASE_URL = OLLAMA_BASE_URL.rstrip("/")
-OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "qwen3:8b")
+
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "").strip()
+if not OLLAMA_MODEL:
+    raise ImproperlyConfigured("OLLAMA_MODEL is not set in the environment or .env file.")
+
+# Summary Configuration
+SUMMARY_MAX_CHARS = int(os.getenv("SUMMARY_MAX_CHARS", "8000"))
 
 
 # Quick-start development settings - unsuitable for production

--- a/src/gist/views.py
+++ b/src/gist/views.py
@@ -8,6 +8,9 @@ from urllib.parse import urlparse
 import socket
 import ipaddress
 
+
+logger = logging.getLogger(__name__)
+
 # LLMクライアントをモジュールレベルで初期化
 llm = ChatOllama(model=settings.OLLAMA_MODEL, base_url=settings.OLLAMA_BASE_URL)
 
@@ -61,11 +64,14 @@ def scrape_page(request):
                     text = soup.body.get_text(separator=' ', strip=True)
                     context['scraped_content'] = text
 
+                    # LLM 入力サイズ制御
+                    truncated_text = text[:settings.SUMMARY_MAX_CHARS]
+
                     # プロンプトを定義
                     prompt = f"""以下のテキストを日本語で要約してください。
 
 テキスト:
-{text}
+{truncated_text}
 
 要約は以下の形式で出力してください。
 タイトル: 記事の内容を一行で表すタイトルを1つ生成してください。
@@ -77,8 +83,14 @@ def scrape_page(request):
                 else:
                     context['scraped_content'] = ''
 
-            except Exception as e:
-                logging.getLogger(__name__).exception("スクレイピング/要約処理でエラー")
+            except requests.RequestException as e:
+                logger.exception("Failed to fetch URL: %s", url)
+                context['error'] = "ページの取得に失敗しました。URLが正しいか確認してください。"
+            except ValueError as e:
+                logger.warning("URL validation error for %s: %s", url, e)
+                context['error'] = str(e)
+            except Exception:
+                logger.exception("An unexpected error occurred during scraping/summarization for URL: %s", url)
                 context['error'] = "エラーが発生しました。しばらくしてからお試しください。"
         else:
             context['error'] = "URLを入力してください。"


### PR DESCRIPTION
This change makes the `OLLAMA_MODEL` environment variable a required setting, similar to `OLLAMA_BASE_URL`. The application will now raise an `ImproperlyConfigured` exception at startup if it is not set.

It also adds a check to ensure that a `.env` file exists at the project root.

Additionally, this commit incorporates several refactoring suggestions from the Coderabbit AI review:
- Validates that `OLLAMA_BASE_URL` starts with `http://` or `https://`.
- Adds a `SUMMARY_MAX_CHARS` environment variable to limit the size of the text sent to the LLM.
- Improves exception handling in the scraping view to be more specific and provide better logging.