### PR TITLE
This commit replaces the placeholder tests for `ScrapingService` and …

### DIFF
--- a/tests/services/test_scraping_service.py
+++ b/tests/services/test_scraping_service.py
@@ -1,3 +1,139 @@
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from apps.gist.services.scraping_service import ScrapingService
+
+
+@pytest.mark.django_db
 class TestScrapingService:
-    def test_always_pass(self):
-        assert True
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://example.com",
+            "https://example.com",
+            "https://example.com/path?query=1",
+        ],
+    )
+    def test_validate_url_valid(self, url):
+        # When: URL をバリデーション
+        # Then: 例外が発生しない
+        ScrapingService.validate_url(url)
+
+    @pytest.mark.parametrize(
+        "url, expected_error_message",
+        [
+            ("ftp://example.com", "URLは http/https のみ対応しています。"),
+            ("http://", "URLのホスト名が不正です。"),
+            ("just-a-string", "URLは http/https のみ対応しています。"),
+        ],
+    )
+    def test_validate_url_invalid(self, url, expected_error_message):
+        # When: 不正な URL をバリデーション
+        # Then: ValueError が発生する
+        with pytest.raises(ValueError, match=expected_error_message):
+            ScrapingService.validate_url(url)
+
+    @patch("socket.getaddrinfo")
+    def test_validate_url_private_host(self, mock_getaddrinfo):
+        # Given: localhost はプライベートホスト
+        url = "http://localhost"
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, 0, 0, "", ("127.0.0.1", 80))
+        ]
+
+        # When: localhost の URL をバリデーション
+        # Then: ValueError が発生する
+        with pytest.raises(ValueError, match="指定のホストは許可されていません。"):
+            ScrapingService.validate_url(url)
+
+    @patch("socket.getaddrinfo")
+    def test_validate_url_public_host(self, mock_getaddrinfo):
+        # Given: example.com はパブリックホスト
+        url = "http://example.com"
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, 0, 0, "", ("93.184.216.34", 80))
+        ]
+
+        # When: example.com の URL をバリデーション
+        # Then: 例外が発生しない
+        ScrapingService.validate_url(url)
+
+    @patch("requests.get")
+    def test_scrape_success(self, mock_get):
+        # Given: 正常な HTML レスポンスを返す mock
+        url = "http://example.com"
+        html_content = """
+        <html>
+            <head><title>Test</title></head>
+            <body>
+                <header>Header</header>
+                <nav>Nav</nav>
+                <main>
+                    <h1>Title</h1>
+                    <p>This is a paragraph.</p>
+                </main>
+                <aside>Aside</aside>
+                <footer>Footer</footer>
+                <script>alert('hello');</script>
+                <style>p { color: red; }</style>
+            </body>
+        </html>
+        """
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = html_content.encode("utf-8")
+        mock_response.headers = {"Content-Type": "text/html"}
+        mock_get.return_value = mock_response
+
+        # When: スクレイピングを実行
+        result = ScrapingService.scrape(url)
+
+        # Then: 不要なタグが除去されたテキストが返る
+        assert result == "Title This is a paragraph."
+        mock_get.assert_called_once()
+
+    @patch("requests.get")
+    def test_scrape_request_exception(self, mock_get):
+        # Given: requests.RequestException を発生させる mock
+        url = "http://example.com"
+        mock_get.side_effect = requests.RequestException("Test error")
+
+        # When: スクレイピングを実行
+        # Then: ValueError が発生する
+        with pytest.raises(ValueError, match="コンテンツ取得に失敗しました: Test error"):
+            ScrapingService.scrape(url)
+
+    @patch("requests.get")
+    def test_scrape_non_html_content(self, mock_get):
+        # Given: 非 HTML コンテンツ (e.g. PDF) を返す mock
+        url = "http://example.com/file.pdf"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"%PDF-1.4..."
+        mock_response.headers = {"Content-Type": "application/pdf"}
+        mock_get.return_value = mock_response
+
+        # When: スクレイピングを実行
+        result = ScrapingService.scrape(url)
+
+        # Then: 空文字列が返る
+        assert result == ""
+
+    @patch("requests.get")
+    def test_scrape_no_body(self, mock_get):
+        # Given: body タグのない HTML を返す mock
+        url = "http://example.com"
+        html_content = "<html><head><title>Test</title></head></html>"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = html_content.encode("utf-8")
+        mock_response.headers = {"Content-Type": "text/html"}
+        mock_get.return_value = mock_response
+
+        # When: スクレイピングを実行
+        result = ScrapingService.scrape(url)
+
+        # Then: 空文字列が返る
+        assert result == ""

--- a/tests/services/test_summarization_service.py
+++ b/tests/services/test_summarization_service.py
@@ -1,3 +1,96 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from apps.gist.services.summarization_service import SummarizationService
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+
+
+@pytest.mark.django_db
 class TestSummarizationService:
-    def test_always_pass(self):
-        assert True
+    @override_settings(OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3")
+    @patch("apps.gist.services.summarization_service.ChatOllama")
+    def test_summarize_success(self, mock_chat_ollama):
+        # Given: LLM の mock を設定
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.invoke.return_value.content = "タイトル: テスト\n要点:\n- テストです"
+        mock_chat_ollama.return_value = mock_llm_instance
+
+        service = SummarizationService()
+        text = "これはテスト用のテキストです。"
+
+        # When: 要約を実行
+        result = service.summarize(text)
+
+        # Then: 要約結果が返り、LLM が呼ばれる
+        assert result == "タイトル: テスト\n要点:\n- テストです"
+        mock_llm_instance.invoke.assert_called_once()
+
+    @override_settings(OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3")
+    @patch("apps.gist.services.summarization_service.ChatOllama")
+    def test_summarize_empty_text(self, mock_chat_ollama):
+        # Given: 空のテキスト
+        mock_llm_instance = MagicMock()
+        mock_chat_ollama.return_value = mock_llm_instance
+        service = SummarizationService()
+        text = ""
+
+        # When: 要約を実行
+        result = service.summarize(text)
+
+        # Then: 空文字列が返り、LLM は呼ばれない
+        assert result == ""
+        mock_llm_instance.invoke.assert_not_called()
+
+    @override_settings(
+        OLLAMA_BASE_URL="http://ollama:11434",
+        OLLAMA_MODEL="llama3",
+        SUMMARY_MAX_CHARS=10,
+    )
+    @patch("apps.gist.services.summarization_service.ChatOllama")
+    def test_summarize_truncates_text(self, mock_chat_ollama):
+        # Given: LLM の mock と文字数制限
+        mock_llm_instance = MagicMock()
+        mock_chat_ollama.return_value = mock_llm_instance
+        service = SummarizationService()
+        text = "This is a very long text that should be truncated."
+
+        # When: 要約を実行
+        service.summarize(text)
+
+        # Then: LLM に渡されるテキストが切り詰められている
+        called_prompt = mock_llm_instance.invoke.call_args[0][0]
+        assert "This is a " in called_prompt
+        assert "very long text" not in called_prompt
+
+    @override_settings(OLLAMA_BASE_URL=None, OLLAMA_MODEL=None)
+    def test_init_missing_settings(self):
+        # When: 設定が不足している状態で初期化
+        # Then: ImproperlyConfigured が発生する
+        with pytest.raises(
+            ImproperlyConfigured,
+            match="OLLAMA_BASE_URL / OLLAMA_MODEL is not configured.",
+        ):
+            SummarizationService()
+
+    @override_settings(
+        OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3"
+    )
+    @patch("apps.gist.services.summarization_service.ChatOllama")
+    def test_summarize_missing_max_chars_setting(self, mock_chat_ollama):
+        # Given: SUMMARY_MAX_CHARS が settings にない
+        from django.conf import settings
+
+        if hasattr(settings, "SUMMARY_MAX_CHARS"):
+            delattr(settings, "SUMMARY_MAX_CHARS")
+
+        mock_chat_ollama.return_value = MagicMock()
+        service = SummarizationService()
+        text = "Some text"
+
+        # When: max_chars を指定せずに要約を実行
+        # Then: AttributeError が発生する
+        with pytest.raises(
+            AttributeError, match="settings.SUMMARY_MAX_CHARS is not defined."
+        ):
+            service.summarize(text)

--- a/tests/services/test_summarization_service.py
+++ b/tests/services/test_summarization_service.py
@@ -1,22 +1,28 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from apps.gist.services.summarization_service import SummarizationService
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 
+from apps.gist.services.summarization_service import SummarizationService
 
-@pytest.mark.django_db
+
 class TestSummarizationService:
     @override_settings(OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3")
     @patch("apps.gist.services.summarization_service.ChatOllama")
     def test_summarize_success(self, mock_chat_ollama):
         # Given: LLM の mock を設定
         mock_llm_instance = MagicMock()
-        mock_llm_instance.invoke.return_value.content = "タイトル: テスト\n要点:\n- テストです"
+        mock_llm_instance.invoke.return_value.content = (
+            "タイトル: テスト\n要点:\n- テストです"
+        )
         mock_chat_ollama.return_value = mock_llm_instance
 
         service = SummarizationService()
+        # ChatOllama が設定値で初期化されることを明示検証
+        mock_chat_ollama.assert_called_once_with(
+            model="llama3", base_url="http://ollama:11434"
+        )
         text = "これはテスト用のテキストです。"
 
         # When: 要約を実行
@@ -25,6 +31,21 @@ class TestSummarizationService:
         # Then: 要約結果が返り、LLM が呼ばれる
         assert result == "タイトル: テスト\n要点:\n- テストです"
         mock_llm_instance.invoke.assert_called_once()
+
+    @override_settings(OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3")
+    @patch("apps.gist.services.summarization_service.ChatOllama")
+    def test_summarize_list_content(self, mock_chat_ollama):
+        mock_llm_instance = MagicMock()
+        mock_llm_instance.invoke.return_value.content = [
+            "タイトル: A",
+            "要点: 1",
+            "要点: 2",
+        ]
+        mock_chat_ollama.return_value = mock_llm_instance
+
+        service = SummarizationService()
+        result = service.summarize("x" * 5, max_chars=5)
+        assert result == "タイトル: A\n要点: 1\n要点: 2"
 
     @override_settings(OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3")
     @patch("apps.gist.services.summarization_service.ChatOllama")
@@ -60,8 +81,9 @@ class TestSummarizationService:
 
         # Then: LLM に渡されるテキストが切り詰められている
         called_prompt = mock_llm_instance.invoke.call_args[0][0]
-        assert "This is a " in called_prompt
-        assert "very long text" not in called_prompt
+        # プロンプトの「テキスト: ... 要約は...」区間のみを検査して誤検知を回避
+        truncated = called_prompt.split("テキスト:\n", 1)[1].split("\n\n要約は", 1)[0]
+        assert truncated == "This is a "
 
     @override_settings(OLLAMA_BASE_URL=None, OLLAMA_MODEL=None)
     def test_init_missing_settings(self):
@@ -73,16 +95,12 @@ class TestSummarizationService:
         ):
             SummarizationService()
 
-    @override_settings(
-        OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3"
-    )
+    @override_settings(OLLAMA_BASE_URL="http://ollama:11434", OLLAMA_MODEL="llama3")
     @patch("apps.gist.services.summarization_service.ChatOllama")
-    def test_summarize_missing_max_chars_setting(self, mock_chat_ollama):
+    def test_summarize_missing_max_chars_setting(self, mock_chat_ollama, monkeypatch):
         # Given: SUMMARY_MAX_CHARS が settings にない
-        from django.conf import settings
-
-        if hasattr(settings, "SUMMARY_MAX_CHARS"):
-            delattr(settings, "SUMMARY_MAX_CHARS")
+        # settings から SUMMARY_MAX_CHARS を安全に取り除く
+        monkeypatch.delattr("django.conf.settings.SUMMARY_MAX_CHARS", raising=False)
 
         mock_chat_ollama.return_value = MagicMock()
         service = SummarizationService()


### PR DESCRIPTION
…`SummarizationService` with a comprehensive suite of unit tests.

- `ScrapingService` tests now cover URL validation, content scraping logic, and error handling using mocks for network requests.
- `SummarizationService` tests cover summarization logic, configuration checks, and text handling, using mocks to avoid actual LLM calls.

All new tests pass and provide significantly improved test coverage for the application's core services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- テスト
  - スクレイピング機能に包括的なテストを追加（URL検証、プライベート/ループバックホスト検出、リダイレクト／タイムアウト／ヘッダーの検証、HTML抽出の正常系・非HTML・本文なし・リクエスト例外の挙動）。
  - 要約機能に包括的なテストを追加（正常系、リスト応答の結合、空入力、文字数上限でのトリミング、設定不足時のエラー、LLM呼び出しの検証）。
  - ネットワーク依存をモック化し、エッジケースを網羅。  
  - 本番コードの動作や公開APIに変更なし。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->