### PR TITLE
Fix(ci): Correct build-check workflow

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image (production)
+      - name: Create .env.test from example
+        run: cp .env.example .env.test
+
+      - name: Build Docker image
         run: |
-          docker compose -f docker-compose.yml --env-file .env.dev build --no-cache --progress=plain web
+          docker compose --progress plain -f docker-compose.yml --env-file .env.test build --no-cache web


### PR DESCRIPTION
The `build-check` workflow was failing due to a missing environment file and an incorrectly placed flag in the `docker compose` command.

This commit addresses the issues by:
- Adding a step to create the `.env.test` file from the `.env.example` template before the build step.
- Moving the `--progress` flag to be a global flag for the `docker compose` command.
- Using the `.env.test` configuration for the build check for better CI/CD practice.
- Renaming the build step to "Build Docker image" for clarity.