### PR TITLE
feat: Add health check for summarization service

### DIFF
--- a/apps/gist/services/__init__.py
+++ b/apps/gist/services/__init__.py
@@ -1,7 +1,11 @@
 from .scraping_service import ScrapingService
-from .summarization_service import SummarizationService
+from .summarization_service import (
+    SummarizationService,
+    SummarizationServiceError,
+)
 
 __all__ = [
     "ScrapingService",
     "SummarizationService",
+    "SummarizationServiceError",
 ]

--- a/apps/gist/views.py
+++ b/apps/gist/views.py
@@ -2,7 +2,11 @@ import logging
 
 from django.shortcuts import render
 
-from gist.services import ScrapingService, SummarizationService
+from gist.services import (
+    ScrapingService,
+    SummarizationService,
+    SummarizationServiceError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +26,14 @@ def scrape_page(request):
             except ValueError as e:
                 # 入力エラーはユーザーにそのまま伝える
                 context["error"] = str(e)
+            except SummarizationServiceError:
+                # 要約サービス固有のエラー
+                logger.exception(
+                    "Summarization service error for URL: %s", url, exc_info=True
+                )
+                context["error"] = (
+                    "要約サービスが現在利用できません。時間をおいて再度お試しください。"
+                )
             except Exception:
                 # それ以外は詳細をログにのみ出し、ユーザーには定型文を返す
                 logger.exception("Error during scraping/summarization for URL: %s", url)

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,5 +20,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", include("src.gist.urls")),
+    path("", include("apps.gist.urls")),
 ]


### PR DESCRIPTION
Adds a health check to the `SummarizationService` before calling the external summarization API.

- A `_health_check` method is added to `SummarizationService` to check the `/health` endpoint of the pvt-llm-api.
- `summarize` now calls `_health_check` and raises a `SummarizationServiceError` if the API is unhealthy.
- The view in `views.py` is updated to specifically catch `SummarizationServiceError` and provide a more informative error message to the user.
- New tests are added to cover the health check scenarios (healthy, unhealthy, and network errors).
- Fixes an incorrect import path in `config/urls.py` from `src.gist.urls` to `apps.gist.urls`.